### PR TITLE
CI only runs on PR branches and `main`

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,12 +1,14 @@
 name: tests
 
 on:
+  # Only run on pushes to main
   push:
     branches:
-      - '*'
-    tags:
-      - '*'
+      - 'main'
+  # Run on all pull-requests
   pull_request:
+  # Allow workflow dispatch from GitHub
+  workflow_dispatch:
 
 jobs:
   linting:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Test (and Deploy on tag)
 
 on:
   # Only run on pushes to main
@@ -9,6 +9,13 @@ on:
   pull_request:
   # Allow workflow dispatch from GitHub
   workflow_dispatch:
+
+concurrency:
+  # Cancel this workflow if it is running,
+  # and then changes are applied on top of the HEAD of the branch,
+  # triggering another run of the workflow
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Prevents CI running twice on all branches.

**What does this PR do?**
Updates `test_and_deploy.yaml` workflow so that it will only run when:
- A pull request is opened/updated
- On pushes to `main` (IE, on merges into main or tag pushes)
- Requested on GitHub

## References

## How has this PR been tested?

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
