### PR TITLE
Allow tag pushes to main to trigger deployment

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'main'
     tags:
-      - 'v*'
+      - 'v**'
   # Run on all pull-requests
   pull_request:
   # Allow workflow dispatch from GitHub

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,10 +1,12 @@
 name: Test (and Deploy on tag)
 
 on:
-  # Only run on pushes to main
+  # Only run on pushes to main, or when version tags are pushed
   push:
     branches:
       - 'main'
+    tags:
+      - 'v*'
   # Run on all pull-requests
   pull_request:
   # Allow workflow dispatch from GitHub


### PR DESCRIPTION
Allows tags matching the pattern `v**` to trigger the test & deploy workflow.

The `v**` tag pattern is now protected, so only admins and maintainers of this repo can trigger releases.