### PR TITLE
Expose tools in meta-package

### DIFF
--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -7,3 +7,10 @@ except PackageNotFoundError:
     pass
 
 # Expose tools under the brainglobe namespace
+import bg_atlasapi
+import bg_space
+import brainreg
+import brainreg_segment
+import brainrender
+import cellfinder_core
+import morphapi

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -11,6 +11,5 @@ import bg_atlasapi
 import bg_space
 import brainreg
 import brainreg_segment
-import brainrender
 import cellfinder_core
 import morphapi

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,0 +1,26 @@
+import inspect
+
+import brainglobe as bg
+
+# Tools that will be exposed in the brainglobe module/namespace
+EXPOSED_TOOLS = [
+    "bg_atlasapi",
+    "bg_space",
+    "brainreg",
+    "brainreg_segment",
+    "brainrender",
+    "cellfinder_core",
+    "morphapi",
+]
+
+
+def test_tool_exposure() -> None:
+    """Assert that each of the user-facing tool sub-modules can be imported."""
+
+    for exposed_tool in EXPOSED_TOOLS:
+        assert hasattr(
+            bg, exposed_tool
+        ), f"brainglobe has no (exposed) tool {exposed_tool}"
+        assert inspect.ismodule(
+            getattr(bg, exposed_tool)
+        ), f"brainglobe.{exposed_tool} is not a submodule"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -8,7 +8,6 @@ EXPOSED_TOOLS = [
     "bg_space",
     "brainreg",
     "brainreg_segment",
-    "brainrender",
     "cellfinder_core",
     "morphapi",
 ]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**What does this PR do?**
Exposes the BrainGlobe tools in the various sub-packages to the user, via imports in `__init__.py`.

## References

- Relates to #5 | Exposes tools via their current, package names. 

## How has this PR been tested?

Local testing via installing into a clean conda environment and running the package tests.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No, although the documentation for this meta package needs some attention at some point.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
