### PR TITLE
Packages not on conda-forge are now optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@ The BrainGlobe project is only possible due to grant funding and the generous su
 ## Installation
 
 The `brainglobe` package can be installed from [PyPI](https://pypi.org/project/brainglobe/) into a Python environment by running
-```python
+```sh
 pip install brainglobe
 ```
+
+If you want to install the additional packages `morphapi` and `cellfinder`, you can specify them as optional dependencies:
+```sh
+pip install brainglobe[morphapi] # Include morphapi
+pip install brainglobe[cellfinder] # Include cellfinder
+pip install brainglobe[morphapi,cellfinder] # Include both morphapi and cellfinder
+```
+
 Alternatively, you can download the source from [PyPI here](https://pypi.org/project/brainglobe/#files).
 
 ## Contributing

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -21,9 +21,9 @@ try:
     import morphapi
 except ImportError:
     _MORPHAPI_INSTALLED = False
-# cellfinder - not exposed, but still check presence
+# cellfinder - not exposed, but still check
 _CELLFINDER_INSTALLED = True
 try:
-    version("cellfinder")
-except PackageNotFoundError:
+    import cellfinder
+except ImportError:
     _CELLFINDER_INSTALLED = False

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -21,9 +21,9 @@ try:
     import morphapi
 except ImportError:
     _MORPHAPI_INSTALLED = False
-# cellfinder - not exposed, but still check
+# cellfinder - not exposed, but still check presence
 _CELLFINDER_INSTALLED = True
 try:
-    import cellfinder
-except ImportError:
+    version("cellfinder")
+except PackageNotFoundError:
     _CELLFINDER_INSTALLED = False

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -12,4 +12,18 @@ import bg_space
 import brainreg
 import brainreg_segment
 import cellfinder_core
-import morphapi
+
+# Determine if optional dependencies were installed,
+# and expose if necessary.
+# morphapi
+_MORPHAPI_INSTALLED = True
+try:
+    import morphapi
+except ImportError:
+    _MORPHAPI_INSTALLED = False
+# cellfinder - not exposed, but still check
+_CELLFINDER_INSTALLED = True
+try:
+    import cellfinder
+except ImportError:
+    _CELLFINDER_INSTALLED = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,10 @@ dependencies = [
   # "bg-atlasgen", [WIP]
   # "brainglobe-napari", [WIP]
   "brainglobe-napari-io",
-  "morphapi>=0.1.3.0",
   "cellfinder-napari",
   "brainreg-segment>=0.0.2",
   "brainreg",
-  "brainreg-napari",
-  "cellfinder"
+  "brainreg-napari"
 ]
 
 [project.optional-dependencies]
@@ -49,6 +47,12 @@ dev = [
   "pre-commit",
   "ruff",
   "setuptools_scm",
+]
+morphapi = [
+  "morphapi>=0.1.3.0"
+]
+cellfinder = [
+  "cellfinder"
 ]
 
 [build-system]

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,7 +1,5 @@
 import inspect
 
-import pytest
-
 import brainglobe as bg
 
 # Tools that will be exposed in the brainglobe module/namespace
@@ -27,19 +25,26 @@ def test_tool_exposure() -> None:
         ), f"brainglobe.{exposed_tool} is not a submodule"
 
     # Now check the optional dependencies
-    # morphapi - if not installed, should not be exposed
-    if not bg._MORPHAPI_INSTALLED:
-        with pytest.raises(ImportError):
-            import bg.morphapi
-    else:
-        assert hasattr(
-            bg, "morphapi"
+    # morphapi
+    bg_has_morphapi = hasattr(bg, "morphapi")
+    if bg._MORPHAPI_INSTALLED:
+        assert (
+            bg_has_morphapi
         ), "brainglobe has morphapi, but it is flagged as installed"
         assert inspect.ismodule(
             getattr(bg, "morphapi")
         ), "brainglobe.morphapi is not a submodule"
-    # cellfinder - if installed, should not be exposed
+    else:
+        assert (
+            not bg_has_morphapi
+        ), "brainglobe has morphapi, but it is flagged as not installed"
+    # cellfinder
+    bg_has_cellfinder = hasattr(bg, "cellfinder")
     if bg._CELLFINDER_INSTALLED:
-        assert not hasattr(
-            bg, "cellfinder"
-        ), "brainglobe has exposed cellfinder"
+        assert (
+            bg_has_cellfinder
+        ), "brainglobe has cellfinder, but it is flagged as installed"
+    else:
+        assert (
+            not bg_has_cellfinder
+        ), "brainglobe has cellfinder, but it is flagged as not installed"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,5 +1,7 @@
 import inspect
 
+import pytest
+
 import brainglobe as bg
 
 # Tools that will be exposed in the brainglobe module/namespace
@@ -25,26 +27,19 @@ def test_tool_exposure() -> None:
         ), f"brainglobe.{exposed_tool} is not a submodule"
 
     # Now check the optional dependencies
-    # morphapi
-    bg_has_morphapi = hasattr(bg, "morphapi")
-    if bg._MORPHAPI_INSTALLED:
-        assert (
-            bg_has_morphapi
+    # morphapi - if not installed, should not be exposed
+    if not bg._MORPHAPI_INSTALLED:
+        with pytest.raises(ImportError):
+            import bg.morphapi
+    else:
+        assert hasattr(
+            bg, "morphapi"
         ), "brainglobe has morphapi, but it is flagged as installed"
         assert inspect.ismodule(
             getattr(bg, "morphapi")
         ), "brainglobe.morphapi is not a submodule"
-    else:
-        assert (
-            not bg_has_morphapi
-        ), "brainglobe has morphapi, but it is flagged as not installed"
-    # cellfinder
-    bg_has_cellfinder = hasattr(bg, "cellfinder")
+    # cellfinder - if installed, should not be exposed
     if bg._CELLFINDER_INSTALLED:
-        assert (
-            bg_has_cellfinder
-        ), "brainglobe has cellfinder, but it is flagged as installed"
-    else:
-        assert (
-            not bg_has_cellfinder
-        ), "brainglobe has cellfinder, but it is flagged as not installed"
+        assert not hasattr(
+            bg, "cellfinder"
+        ), "brainglobe has exposed cellfinder"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,5 +1,7 @@
 import inspect
 
+import pytest
+
 import brainglobe as bg
 
 # Tools that will be exposed in the brainglobe module/namespace
@@ -24,27 +26,25 @@ def test_tool_exposure() -> None:
             getattr(bg, exposed_tool)
         ), f"brainglobe.{exposed_tool} is not a submodule"
 
-    # Now check the optional dependencies
-    # morphapi
-    bg_has_morphapi = hasattr(bg, "morphapi")
+    # Determine if optional dependencies were installed,
+    # and exposed if necessary
+
+    # morphapi - should be exposed if installed
     if bg._MORPHAPI_INSTALLED:
-        assert (
-            bg_has_morphapi
-        ), "brainglobe has morphapi, but it is flagged as installed"
+        assert hasattr(
+            bg, "morphapi"
+        ), "morphapi is installed but not exposed."
         assert inspect.ismodule(
-            getattr(bg, "morphapi")
-        ), "brainglobe.morphapi is not a submodule"
+            bg.morphapi
+        ), "brainglobe.morphapi is not a module"
     else:
-        assert (
-            not bg_has_morphapi
-        ), "brainglobe has morphapi, but it is flagged as not installed"
-    # cellfinder
-    bg_has_cellfinder = hasattr(bg, "cellfinder")
-    if bg._CELLFINDER_INSTALLED:
-        assert (
-            bg_has_cellfinder
-        ), "brainglobe has cellfinder, but it is flagged as installed"
+        assert not hasattr(bg, "morphapi")
+
+    # cellfinder - should not be exposed if installed
+    if not bg._CELLFINDER_INSTALLED:
+        with pytest.raises(ImportError):
+            pass
     else:
-        assert (
-            not bg_has_cellfinder
-        ), "brainglobe has cellfinder, but it is flagged as not installed"
+        assert not hasattr(
+            bg, "cellfinder"
+        ), "brainglobe.cellfinder is exposed"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,7 +1,5 @@
 import inspect
 
-import pytest
-
 import brainglobe as bg
 
 # Tools that will be exposed in the brainglobe module/namespace
@@ -41,10 +39,7 @@ def test_tool_exposure() -> None:
         assert not hasattr(bg, "morphapi")
 
     # cellfinder - should not be exposed if installed
-    if not bg._CELLFINDER_INSTALLED:
-        with pytest.raises(ImportError):
-            pass
-    else:
+    if bg._CELLFINDER_INSTALLED:
         assert not hasattr(
             bg, "cellfinder"
         ), "brainglobe.cellfinder is exposed"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -9,8 +9,8 @@ EXPOSED_TOOLS = [
     "brainreg",
     "brainreg_segment",
     "cellfinder_core",
-    "morphapi",
 ]
+OPTIONAL_TOOLS = ["morphapi", "cellfinder"]
 
 
 def test_tool_exposure() -> None:
@@ -23,3 +23,28 @@ def test_tool_exposure() -> None:
         assert inspect.ismodule(
             getattr(bg, exposed_tool)
         ), f"brainglobe.{exposed_tool} is not a submodule"
+
+    # Now check the optional dependencies
+    # morphapi
+    bg_has_morphapi = hasattr(bg, "morphapi")
+    if bg._MORPHAPI_INSTALLED:
+        assert (
+            bg_has_morphapi
+        ), "brainglobe has morphapi, but it is flagged as installed"
+        assert inspect.ismodule(
+            getattr(bg, "morphapi")
+        ), "brainglobe.morphapi is not a submodule"
+    else:
+        assert (
+            not bg_has_morphapi
+        ), "brainglobe has morphapi, but it is flagged as not installed"
+    # cellfinder
+    bg_has_cellfinder = hasattr(bg, "cellfinder")
+    if bg._CELLFINDER_INSTALLED:
+        assert (
+            bg_has_cellfinder
+        ), "brainglobe has cellfinder, but it is flagged as installed"
+    else:
+        assert (
+            not bg_has_cellfinder
+        ), "brainglobe has cellfinder, but it is flagged as not installed"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Some BrainGlobe packages are not yet available on conda-forge, and thus we cannot put this meta-package on conda-forge yet.

Pending an upload of the missing dependencies, we can turn them into optional dependencies for the time being which will allow us to get the "base" package onto conda-forge.

**What does this PR do?**
`cellfinder` and `morphapi` are now optional dependencies, and can be specified when `pip`-installing.

- `cellfinder` is nominated for removal anyway, so this package may simply be removed in a future update (see https://github.com/brainglobe/BrainGlobe/issues/20)
- `morphapi` is being worked on as per #9.

## References
- Concerns #9 | [Comment](https://github.com/brainglobe/brainglobe-meta/issues/9#issuecomment-1596826090)

## How has this PR been tested?

Testing via upload to testpypi and clean install into a conda environment.

## Is this a breaking change?

Kind of - installation now requires optional dependencies to reach the same state as `v.0.0.0`. But otherwise all existing scripts/workflows will be backwards compatible.

## Does this PR require an update to the documentation?

README.md has been updated to reflect these changes. Overall documentation doesn't need to change.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
