### PR TITLE
Update tools provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ We have three aims:
 - Build a community of neuroscientists and developers to share knowledge, build software and engage
   with the scientific, and open-source community (e.g. by organising hackathons).
 
+## This Package Provides:
+
+This package provides all BrainGlobe tools in one place, requested [through a single command](#installation).
+
+You can read more about the individual tools on the [documentation website](https://brainglobe.info/documentation/index.html).
+Currently included packages, and whether they come with the `pip` and `conda-forge` installs are listed below:
+|               Package                |  `pip`   | `conda`  | How to access |                               Documentation                               |
+| :----------------------------------: | :------: | :------: | :-----------: | :-----------------------------------------------------------------------: |
+| BrainGlobe Atlas API (`bg-atlasapi`) | &#x2611; | &#x2611; |               |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
+|              `bg-space`              | &#x2611; | &#x2611; |               |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
+|              `brainreg`              | &#x2611; | &#x2611; |               |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
+|          `brainreg-segment`          | &#x2611; | &#x2611; |               | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
+|            `brainrender`             |          |          |               |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
+|             `cellfinder`             | &#x2611; |          |               |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
+|              `morphapi`              | &#x2611; |          |               |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |
+
+
 ### [**Funding**](https://brainglobe.info/funders.html#funders) Information
 
 The BrainGlobe project is only possible due to grant funding and the generous support of host institutions, whose information [can be found on this website](https://brainglobe.info/funders.html#funders).
@@ -27,19 +44,38 @@ The BrainGlobe project is only possible due to grant funding and the generous su
 
 ## Installation
 
+We recommend users install into a fresh virtual environment using `pip`; since this will resolve all complex dependencies (like `tensorflow`) automatically, across all operating systems and (compatible) Python versions.
+
+### **Recommended**: via `pip`
 The `brainglobe` package can be installed from [PyPI](https://pypi.org/project/brainglobe/) into a Python environment by running
 ```sh
 pip install brainglobe
 ```
-
-If you want to install the additional packages `morphapi` and `cellfinder`, you can specify them as optional dependencies:
-```sh
-pip install brainglobe[morphapi] # Include morphapi
-pip install brainglobe[cellfinder] # Include cellfinder
-pip install brainglobe[morphapi,cellfinder] # Include both morphapi and cellfinder
-```
-
+This will fetch and install all `brainglobe` packages and tools into your current environment.
 Alternatively, you can download the source from [PyPI here](https://pypi.org/project/brainglobe/#files).
+
+### **Alternatives**: via `conda`
+We are currently in the process of making BrainGlobe's tools available from `conda-forge` as an alternative to `PyPI`.
+However certain tools are currently not available on `conda-forge`, specifically:
+- `brainrender` (in progress)
+- `morphapi` (in progress)
+- `cellfinder` ([see below](#cellfinder-and-conda-forge))
+
+In your desired virtual environment, run
+```sh
+conda install -c conda-forge brainglobe
+```
+to install the compatible BrainGlobe tools.
+
+#### **`cellfinder` and `conda-forge`**
+
+Choosing to install via `conda` will provide the (source code for the) `cellfinder` tool.
+However due to an ongoing issue with `tensorflow`'s availability on `conda-forge`, the install _will not_ provide `tensorflow` itself.
+This is because `tensorflow` versions newer than `1.14.0` are not provided via `conda` channels, and `cellfinder-core` (one of the brainglobe tools) requires a version between `2.5.0` and `2.11.1`.
+See [this issue on GitHub for more details](https://github.com/conda-forge/cellfinder-core-feedstock/issues/13).
+Users that want to run `cellfinder` will need to manually install a compatible version of `tensorflow` into their environment, before running the `conda install` command above.
+
+---
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ This package provides all BrainGlobe tools in one place, requested [through a si
 
 You can read more about the individual tools on the [documentation website](https://brainglobe.info/documentation/index.html).
 Currently included packages, and whether they come with the `pip` and `conda-forge` installs are listed below:
-|       Package        |  `pip`   | `conda`  |    `from brainglobe import`     |                               Documentation                               |
-| :------------------: | :------: | :------: | :-----------------------------: | :-----------------------------------------------------------------------: |
-| BrainGlobe Atlas API | &#x2611; | &#x2611; |          `bg_atlasapi`          |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
-|      `bg-space`      | &#x2611; | &#x2611; |           `bg-space`            |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
-|      `brainreg`      | &#x2611; | &#x2611; |           `brainreg`            |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
-|  `brainreg-segment`  | &#x2611; | &#x2611; |       `brainreg_segment`        | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
-|    `brainrender`     |          |          |                                 |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
-|     `cellfinder`     | &#x2611; | Pending  | `cellfinder_core`, `cellfinder` |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
-|      `morphapi`      | &#x2611; | Pending  |           `morphapi`            |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |
+|       Package        |  `pip`   | `conda`  | `from brainglobe import` |                               Documentation                               |
+| :------------------: | :------: | :------: | :----------------------: | :-----------------------------------------------------------------------: |
+| BrainGlobe Atlas API | &#x2611; | &#x2611; |      `bg_atlasapi`       |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
+|      `bg-space`      | &#x2611; | &#x2611; |        `bg-space`        |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
+|      `brainreg`      | &#x2611; | &#x2611; |        `brainreg`        |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
+|  `brainreg-segment`  | &#x2611; | &#x2611; |    `brainreg_segment`    | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
+|    `brainrender`     |          |          |                          |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
+|     `cellfinder`     | &#x2611; | Pending  |    `cellfinder_core`     |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
+|      `morphapi`      | &#x2611; | Pending  |        `morphapi`        |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,26 +19,27 @@ We have three aims:
 - Build a community of neuroscientists and developers to share knowledge, build software and engage
   with the scientific, and open-source community (e.g. by organising hackathons).
 
-## This Package Provides:
+### [**Funding**](https://brainglobe.info/funders.html#funders) Information
+
+The BrainGlobe project is only possible due to grant funding and the generous support of host institutions, whose information [can be found on this website](https://brainglobe.info/funders.html#funders).
+
+---
+
+## BrainGlobe tools
 
 This package provides all BrainGlobe tools in one place, requested [through a single command](#installation).
 
 You can read more about the individual tools on the [documentation website](https://brainglobe.info/documentation/index.html).
 Currently included packages, and whether they come with the `pip` and `conda-forge` installs are listed below:
-|               Package                |  `pip`   | `conda`  | How to access |                               Documentation                               |
-| :----------------------------------: | :------: | :------: | :-----------: | :-----------------------------------------------------------------------: |
-| BrainGlobe Atlas API (`bg-atlasapi`) | &#x2611; | &#x2611; |               |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
-|              `bg-space`              | &#x2611; | &#x2611; |               |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
-|              `brainreg`              | &#x2611; | &#x2611; |               |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
-|          `brainreg-segment`          | &#x2611; | &#x2611; |               | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
-|            `brainrender`             |          |          |               |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
-|             `cellfinder`             | &#x2611; |          |               |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
-|              `morphapi`              | &#x2611; |          |               |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |
-
-
-### [**Funding**](https://brainglobe.info/funders.html#funders) Information
-
-The BrainGlobe project is only possible due to grant funding and the generous support of host institutions, whose information [can be found on this website](https://brainglobe.info/funders.html#funders).
+|       Package        |  `pip`   | `conda`  |    `from brainglobe import`     |                               Documentation                               |
+| :------------------: | :------: | :------: | :-----------------------------: | :-----------------------------------------------------------------------: |
+| BrainGlobe Atlas API | &#x2611; | &#x2611; |          `bg_atlasapi`          |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
+|      `bg-space`      | &#x2611; | &#x2611; |           `bg-space`            |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
+|      `brainreg`      | &#x2611; | &#x2611; |           `brainreg`            |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
+|  `brainreg-segment`  | &#x2611; | &#x2611; |       `brainreg_segment`        | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
+|    `brainrender`     |          |          |                                 |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
+|     `cellfinder`     | &#x2611; | Pending  | `cellfinder_core`, `cellfinder` |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
+|      `morphapi`      | &#x2611; | Pending  |           `morphapi`            |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |
 
 ---
 

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -24,7 +24,6 @@ except ImportError:
 # cellfinder, and cellfinder_core
 _CELLFINDER_INSTALLED = True
 try:
-    import cellfinder
     import cellfinder_core
 except ImportError:
     _CELLFINDER_INSTALLED = False

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -11,19 +11,20 @@ import bg_atlasapi
 import bg_space
 import brainreg
 import brainreg_segment
-import cellfinder_core
 
-# Determine if optional dependencies were installed,
-# and expose if necessary.
+# Expose tools that may not be present
+# if a conda install was performed
+
 # morphapi
 _MORPHAPI_INSTALLED = True
 try:
     import morphapi
 except ImportError:
     _MORPHAPI_INSTALLED = False
-# cellfinder - not exposed, but still check
+# cellfinder, and cellfinder_core
 _CELLFINDER_INSTALLED = True
 try:
     import cellfinder
+    import cellfinder_core
 except ImportError:
     _CELLFINDER_INSTALLED = False

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -1,5 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from ._tensorflow_handle import _CELLFINDER_FUNCTIONAL as _CELLFINDER_INSTALLED
+
 try:
     __version__ = version("brainglobe")
 except PackageNotFoundError:
@@ -21,9 +23,12 @@ try:
     import morphapi
 except ImportError:
     _MORPHAPI_INSTALLED = False
-# cellfinder, and cellfinder_core
-_CELLFINDER_INSTALLED = True
-try:
+
+# cellfinder and associated packages
+if _CELLFINDER_INSTALLED:
     import cellfinder_core
-except ImportError:
-    _CELLFINDER_INSTALLED = False
+else:
+    # Under the cellfinder_core name,
+    # import an error-throwing function that points users to the
+    # instructions for getting the cellfinder tool working
+    from ._tensorflow_handle import throw_error_on_call as cellfinder_core

--- a/brainglobe/_tensorflow_handle.py
+++ b/brainglobe/_tensorflow_handle.py
@@ -1,0 +1,22 @@
+from importlib.metadata import PackageNotFoundError, version
+
+
+def throw_error_on_call() -> None:
+    raise PackageNotFoundError(
+        "Python cannot locate the tensorflow package, "
+        "which is required to use cellfinder tools. "
+        "Please manually install tensorflow into your environment; "
+        "see https://github.com/brainglobe/brainglobe-meta#installation "
+        "for more details."
+    )
+
+
+_CELLFINDER_FUNCTIONAL = True
+try:
+    version("tensorflow")
+except PackageNotFoundError:
+    # No tensorflow is visible to the Python interpreter.
+    # Do not expose the cellfinder_core package as it is unusable.
+    # Instead, import a cellfinder_core name that will
+    # throw an error if invoked.
+    _CELLFINDER_FUNCTIONAL = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "napari[all]",
   "brainglobe-utils",
   "bg-space>=0.5.0",
-  "cellfinder-core>=0.3",
+  "cellfinder-core[tensorflow]>=0.3",
   "imio",
   "bg-atlasapi>=1.0.0",
   # "bg-atlasgen", [WIP]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,6 @@ dev = [
   "ruff",
   "setuptools_scm",
 ]
-morphapi = [
-
-]
-cellfinder = [
-
-]
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "napari[all]",
   "brainglobe-utils",
   "bg-space>=0.5.0",
-  "cellfinder-core[tensorflow]>=0.3",
+  "cellfinder-core>=0.3",
   "imio",
   "bg-atlasapi>=1.0.0",
   # "bg-atlasgen", [WIP]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 dependencies = [
   "napari[all]",
+  "brainglobe-utils",
   "bg-space>=0.5.0",
   "cellfinder-core>=0.3",
   "imio",
@@ -30,10 +31,12 @@ dependencies = [
   # "bg-atlasgen", [WIP]
   # "brainglobe-napari", [WIP]
   "brainglobe-napari-io",
+  "morphapi>=0.1.3.0",
   "cellfinder-napari",
   "brainreg-segment>=0.0.2",
   "brainreg",
-  "brainreg-napari"
+  "brainreg-napari",
+  "cellfinder"
 ]
 
 [project.optional-dependencies]
@@ -49,10 +52,10 @@ dev = [
   "setuptools_scm",
 ]
 morphapi = [
-  "morphapi>=0.1.3.0"
+
 ]
 cellfinder = [
-  "cellfinder"
+
 ]
 
 [build-system]

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -39,7 +39,11 @@ def test_tool_exposure() -> None:
         assert not hasattr(bg, "morphapi")
 
     # cellfinder - should not be exposed if installed
+    # cellfinder_core - should be exposed if installed
     if bg._CELLFINDER_INSTALLED:
         assert not hasattr(
             bg, "cellfinder"
         ), "brainglobe.cellfinder is exposed"
+        assert hasattr(
+            bg, "cellfinder_core"
+        ), "brainglobe.cellfinder_core is not exposed"

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -1,5 +1,8 @@
 import inspect
 
+import pytest
+from importlib_metadata import PackageNotFoundError
+
 import brainglobe as bg
 
 # Tools that will be exposed in the brainglobe module/namespace
@@ -47,3 +50,8 @@ def test_tool_exposure() -> None:
         assert hasattr(
             bg, "cellfinder_core"
         ), "brainglobe.cellfinder_core is not exposed"
+    else:
+        # cellfinder_core should be aliased to a function
+        # that throws an error when invoked
+        with pytest.raises(PackageNotFoundError):
+            bg.cellfinder_core()


### PR DESCRIPTION
## Description

Waiting on:
- [ ] https://github.com/brainglobe/cellfinder-core/pull/187,
- [ ] A new `PyPI` release of `cellfinder_core`,
- [ ] Step 2 of https://github.com/brainglobe/BrainGlobe/issues/27,

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Allows the command
```sh
pip install brainglobe
``` 
to install all currently-available BrainGlobe tools, and makes the tools exposed to users compatible with a `conda` install.

Also enables step 3 of https://github.com/brainglobe/BrainGlobe/issues/27.

**What does this PR do?**

## References

Resolves the `brainglobe-meta` task in https://github.com/brainglobe/BrainGlobe/issues/27.

## How has this PR been tested?

Local testing of new import guards via `pip` installation.

## Is this a breaking change?

No. 

It also means there's no longer any need for the optional `morphapi` and `cellfinder` dependencies to be specified.

## Does this PR require an update to the documentation?

Install instructions have been updated to reflect the `pip` install manifest and the (to be completed) `conda-forge` recipe.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
