### PR TITLE
Update to `brainreg 1.0.0`, and `brainreg-segment` -> `brainglobe-segmentation`.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Currently included packages, and whether they come with the `pip` and `conda-for
 | BrainGlobe Atlas API | &#x2611; | &#x2611; |      `bg_atlasapi`       |   [Site](https://brainglobe.info/documentation/bg-atlasapi/index.html)    |
 |      `bg-space`      | &#x2611; | &#x2611; |        `bg-space`        |     [Site](https://brainglobe.info/documentation/bg-space/index.html)     |
 |      `brainreg`      | &#x2611; | &#x2611; |        `brainreg`        |     [Site](https://brainglobe.info/documentation/brainreg/index.html)     |
-|  `brainreg-segment`  | &#x2611; | &#x2611; |    `brainreg_segment`    | [Site](https://brainglobe.info/documentation/brainreg-segment/index.html) |
+|  `brainglobe-segmentation`  | &#x2611; | &#x2611; |    `brainglobe_segmentation`    | [Site](https://brainglobe.info/documentation/brainglobe-segmentation/index.html) |
 |    `brainrender`     |          |          |                          |   [Site](https://brainglobe.info/documentation/brainrender/index.html)    |
 |     `cellfinder`     | &#x2611; | Pending  |    `cellfinder_core`     |    [Site](https://brainglobe.info/documentation/cellfinder/index.html)    |
 |      `morphapi`      | &#x2611; | Pending  |        `morphapi`        |     [Site](https://brainglobe.info/documentation/morphapi/index.html)     |

--- a/brainglobe/__init__.py
+++ b/brainglobe/__init__.py
@@ -12,7 +12,7 @@ except PackageNotFoundError:
 import bg_atlasapi
 import bg_space
 import brainreg
-import brainreg_segment
+import brainglobe_segmentation
 
 # Expose tools that may not be present
 # if a conda install was performed

--- a/docs/brainglobe-interdependencies.md
+++ b/docs/brainglobe-interdependencies.md
@@ -19,9 +19,8 @@ Packages are listed top to bottom based on the number of brainglobe dependencies
 |       `morphio`        |       https://github.com/brainglobe/morphapi       |       https://pypi.org/project/morphio        |                           See notes                           |
 | `brainglobe-napari-io` | https://github.com/brainglobe/brainglobe-napari-io | https://pypi.org/project/brainglobe-napari-io | https://github.com/conda-forge/brainglobe-napari-io-feedstock |
 |     `bg-atlasgen`      |     https://github.com/brainglobe/bg-atlasgen      |                   See notes                   |                           See notes                           |
-|   `brainreg-segment`   |   https://github.com/brainglobe/brainreg-segment   |   https://pypi.org/project/brainreg-segment   |   https://github.com/conda-forge/brainreg-segment-feedstock   |
+|   `brainglobe-segmentation`   |   https://github.com/brainglobe/brainglobe-segmentation   |   https://pypi.org/project/brainglobe-segmentation   |   https://github.com/conda-forge/brainglobe-segmentation-feedstock   |
 |  `cellfinder-napari`   |  https://github.com/brainglobe/cellfinder-napari   |  https://pypi.org/project/cellfinder-napari   |  https://github.com/conda-forge/cellfinder-napari-feedstock   |
-|   `brainreg-napari`    |   https://github.com/brainglobe/brainreg-napari    |   https://pypi.org/project/brainreg-napari    |   https://github.com/conda-forge/brainreg-napari-feedstock    |
 |      `cellfinder`      |      https://github.com/brainglobe/cellfinder      |      https://pypi.org/project/cellfinder      |                         Not available                         |
 
 
@@ -34,5 +33,3 @@ Packages are listed top to bottom based on the number of brainglobe dependencies
   - [Repository](https://github.com/brainglobe/brainglobe-napari)
   - Napari plugin for [bg-atlasapi](#bg-atlasapi). Note that repository README uses the name "brainglobe" for "bg-atlasapi" due to a historical renaming.
   - Dependencies: `bg-atlasapi`
-- `brainreg`
-  - Has optional `[napari]` dependency which just goes away and installs `brainreg-napari` package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "brainglobe"
 authors = [{ name = "BrainGlobe", email = "code@adamltyson.com" }]
 description = "Python-based tools for computational neuroanatomy."
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 license = { text = "BSD-3-Clause" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "bg-space>=0.5.0",
   "brainglobe-utils",
   "bg-atlasapi>=1.0.0",
-  "brainreg>=1.0.0",
+  "brainreg[napari]>=1.0.0",
   # brainglobe-napari [WIP],
   "imio",
   "cellfinder-core>=0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,15 @@ dependencies = [
   "bg-space>=0.5.0",
   "brainglobe-utils",
   "bg-atlasapi>=1.0.0",
-  "brainreg",
+  "brainreg>=1.0.0",
   # brainglobe-napari [WIP],
   "imio",
   "cellfinder-core>=0.3",
   "morphapi>=0.1.3.0",
   "brainglobe-napari-io",
   # bg-atlasgen [LOCAL ONLY],
-  "brainreg-segment>=0.0.2",
+  "brainglobe-segmentation>=1.0.0",
   "cellfinder-napari",
-  "brainreg-napari",
   "cellfinder",
 ]
 

--- a/tests/test_unit/test_tool_exposure.py
+++ b/tests/test_unit/test_tool_exposure.py
@@ -10,7 +10,7 @@ EXPOSED_TOOLS = [
     "bg_atlasapi",
     "bg_space",
     "brainreg",
-    "brainreg_segment",
+    "brainglobe_segmentation",
     "cellfinder_core",
 ]
 OPTIONAL_TOOLS = ["morphapi", "cellfinder"]


### PR DESCRIPTION
Updates the meta-package with the [`brainreg` changes](https://brainglobe.info/blog/version1/brainreg_update_live.html).

- `brainreg` now pinned at `v1.0.0`. Napari plugin is auto-included.
- `brainreg-napari` is no longer fetched.
- `brainglobe-segmentation` `v1.0.0` superceeds `brainreg-segment`.

Side effects:

- Python 3.8 support dropped. Python 3.9 is now minimum supported version. Forced by `brainreg` update.

On merge: tag and release `v0.3.0`.