### PR TITLE
brainglobe-space update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,15 @@ classifiers = [
 ]
 
 dependencies = [
-  "bg-atlasapi>=1.0.2,<2",
-  "bg-space>=0.6.0,<1",
+  "bg-atlasapi>=1.0.3,<2",
   "brainglobe-heatmap>=0.5.2,<1",
-  "brainglobe-napari-io>=0.3.1,<1",
+  "brainglobe-napari-io>=0.3.3,<1",
   "brainglobe-segmentation>=1.2.0,<2",
+  "brainglobe-space>=1.0.0,<2",
   "brainglobe-utils>=0.3.3,<1",
-  "brainreg[napari]>=1.0.2,<2",
+  "brainreg[napari]>=1.0.4,<2",
   "brainrender-napari>=0.0.2,<1",
-  "brainrender>=2.1.3,<3",
+  "brainrender>=2.1.5,<3",
   "cellfinder[napari]>=1.1.0,<2",
   "imio>=0.3.0,<1",
   "napari[all]",


### PR DESCRIPTION
See https://github.com/brainglobe/brainglobe-space/issues/37.

Updates each of the affected packages minimum version, as well as changing `bg-space` to `brainglobe-space` itself.

Tests will fail until all of the dependent packages in https://github.com/brainglobe/brainglobe-space/issues/37 have had the appropriate updated version released to PyPI.