### PR TITLE
add codecov token

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   build_sdist_wheels:
     name: Build source distribution


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
Codecov is currently complaining on all actions runs with: `secret-codecov-token is not set. This will be required in the future.`

**What does this PR do?**
This PR ensures `test_and_deploy` is using the codecov token, as recommended in the [readme for the neuroinformatics unit test action](https://github.com/neuroinformatics-unit/actions/tree/main/test#python-test-action)

## References

None

## How has this PR been tested?

Hopefully codecov won't error on the github actions runs for this PR

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
