### PR TITLE
Update pinned dependencies and add brainglobe-napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,18 +20,18 @@ classifiers = [
 ]
 
 dependencies = [
-  "brainglobe-atlasapi>=2.0.6,<3",
+  "brainglobe-atlasapi>=2.0.7,<3",
   "brainglobe-heatmap>=0.5.3,<1",
   "brainglobe-napari-io>=0.3.4,<1",
   "brainglobe-segmentation>=1.2.4,<2",
   "brainglobe-space>=1.0.2,<2",
-  "brainglobe-utils>=0.5.0,<1",
-  "brainreg[napari]>=1.0.9,<2",
+  "brainglobe-utils>=0.6.0,<1",
+  "brainreg[napari]>=1.0.10,<2",
   "brainrender-napari>=0.0.3,<1",
-  "brainrender>=2.1.9,<3",
-  "cellfinder[napari]>=1.3.0,<2",
+  "brainrender>=2.1.10,<3",
+  "cellfinder[napari]>=1.3.1,<2",
   "napari[all]",
-  # brainglobe-napari [WIP],
+  "brainglobe-napari>=0.0.4, <2" ,
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "brainrender>=2.1.10,<3",
   "cellfinder[napari]>=1.3.1,<2",
   "napari[all]",
-  "brainglobe-napari>=0.0.4, <2" ,
+  "brainrender-napari>=0.0.4, <2" ,
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In the light of brainglobe-utils 0.6.0 I've updated the pinned versions of all dependencies.

I also added `brainrender-napari`. Although it's not finished, I think it's valuable, and we often suggest it to users. 