### PR TITLE
Schedule tests to run weekly

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -9,6 +9,9 @@ on:
       - 'v**'
   # Run on all pull-requests
   pull_request:
+  schedule:
+  # Runs at 6:10am UTC on Monday
+    - cron: '10 6 * * 1'
   # Allow workflow dispatch from GitHub
   workflow_dispatch:
 


### PR DESCRIPTION
Schedule tests to run weekly to make sure there are no installation issues, and to keep the cache fresh.